### PR TITLE
NUCLEO_H743ZI: add CRC

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1496,7 +1496,7 @@
         },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0813"],
-        "device_has_add": ["TRNG", "ANALOGOUT"],
+        "device_has_add": ["TRNG", "ANALOGOUT", "CRC"],
         "release_versions": ["2", "5"],
         "device_name": "STM32H743ZI"
     },


### PR DESCRIPTION
Tests OK
- tests-mbed_drivers-crc, tests-mbed_hal-crc 
- ARM, IAR, GCC_ARM
