### PR TITLE
NUCLEO_H743ZI: add IAR exporter + use DTCM RAM

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_ARM_MICRO/stm32h743xI.sct
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_ARM_MICRO/stm32h743xI.sct
@@ -27,7 +27,7 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32H743ZI: 2MB FLASH (0x200000) + 512 KB SRAM (0x80000) @ 0x24000000
+; 2MB FLASH (0x200000)
 LR_IROM1 0x08000000 0x200000  {    ; load region size_region
 
   ER_IROM1 0x08000000 0x200000  {  ; load address = execution address
@@ -36,10 +36,10 @@ LR_IROM1 0x08000000 0x200000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 166 vectors = 664 bytes (0x298) to be reserved in RAM
-  RW_IRAM1 (0x24000000+0x298) (0x80000-0x298)  {  ; RW data
+  ; 128KB DTCM RAM (0x20000)
+  ; 166 vectors = 664 bytes (0x298) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x298) (0x20000-0x298)  {  ; RW data
    .ANY (+RW +ZI)
   }
 
 }
-

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_ARM_STD/stm32h743xI.sct
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_ARM_STD/stm32h743xI.sct
@@ -27,7 +27,7 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32H743ZI: 2MB FLASH (0x200000) + 512 KB SRAM (0x80000) @ 0x24000000
+; 2MB FLASH (0x200000)
 LR_IROM1 0x08000000 0x200000  {    ; load region size_region
 
   ER_IROM1 0x08000000 0x200000  {  ; load address = execution address
@@ -36,10 +36,10 @@ LR_IROM1 0x08000000 0x200000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 166 vectors = 664 bytes (0x298) to be reserved in RAM
-  RW_IRAM1 (0x24000000+0x298) (0x80000-0x298)  {  ; RW data
+  ; 128KB DTCM RAM (0x20000)
+  ; 166 vectors = 664 bytes (0x298) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x298) (0x20000-0x298)  {  ; RW data
    .ANY (+RW +ZI)
   }
 
 }
-

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_GCC_ARM/STM32H743xI.ld
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_GCC_ARM/STM32H743xI.ld
@@ -2,7 +2,7 @@
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 2048K
-  RAM (rwx)  : ORIGIN = 0x24000298, LENGTH = 512K - 0x298
+  RAM (rwx)  : ORIGIN = 0x20000298, LENGTH = 128K - 0x298
 }
 
 /* Linker script to place sections and symbol values. Should be used together

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_IAR/stm32h743xI.icf
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/TOOLCHAIN_IAR/stm32h743xI.icf
@@ -1,22 +1,23 @@
-/* [ROM = 2Mb = 0x200000] */
-define symbol __intvec_start__     = 0x08000000;
-define symbol __region_ROM_start__ = 0x08000000;
-define symbol __region_ROM_end__   = 0x08000000 + 0x200000 - 1;
+// 2MB FLASH (0x200000)
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x200000; }
+define symbol __intvec_start__     = MBED_APP_START;
+define symbol __region_ROM_start__ = MBED_APP_START;
+define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
-/* [RAM = 512kb = 0x80000] Vector table dynamic copy: 166 vectors = 664 bytes (0x298) to be reserved in RAM */
-define symbol __NVIC_start__          = 0x24000000;
-define symbol __NVIC_end__            = 0x24000000 + 0x298 - 1;
-define symbol __region_RAM_start__    = 0x24000000 + 0x298; /* Aligned on 8 bytes */
-define symbol __region_RAM_end__      = 0x24000000 + 0x80000 - 1;
+// 128KB DTCM RAM (0x20000)
+// Vector table dynamic copy: 166 vectors = 664 bytes (0x298) to be reserved in RAM
+define symbol __region_RAM_start__ = 0x20000000 + 0x298; // Aligned on 8 bytes
+define symbol __region_RAM_end__   = 0x20000000 + 0x20000 - 1;
 
-/* Memory regions */
+// Memory regions
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
-/* Stack and Heap */
-define symbol __size_cstack__ = 0x8000;
-define symbol __size_heap__   = 0x10000;
+// Stack and Heap
+define symbol __size_cstack__ = 0x400; // 1KB
+define symbol __size_heap__   = 0x10000; // 64KB
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };

--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/cmsis_nvic.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/device/cmsis_nvic.h
@@ -35,6 +35,6 @@
 // MCU Peripherals: 150 vectors = 600 bytes from 0x40 to 0x297
 // Total: 166 vectors = 664 bytes (0x298) to be reserved in RAM
 #define NVIC_NUM_VECTORS      166
-#define NVIC_RAM_VECTOR_ADDRESS 0x24000000    // Vectors positioned at start of RAM
+#define NVIC_RAM_VECTOR_ADDRESS 0x20000000    // Vectors positioned at start of DTCM RAM
 
 #endif

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -95,7 +95,9 @@
        defined(TARGET_STM32F411RE) ||\
        defined(TARGET_STM32F446RE) ||\
        defined(TARGET_STM32F446VE) ||\
-       defined(TARGET_STM32F446ZE))
+       defined(TARGET_STM32F446ZE) ||\
+       defined(TARGET_STM32H743ZI) ||\
+       defined(TARGET_STM32H753ZI))
 #define INITIAL_SP              (0x20020000UL)
 
 #elif (defined(TARGET_STM32F429ZI) ||\
@@ -119,11 +121,6 @@
 #elif (defined(TARGET_STM32F767ZI) ||\
        defined(TARGET_STM32F769NI))
 #define INITIAL_SP              (0x20080000UL)
-
-#elif (defined(TARGET_STM32H743ZI) ||\
-       defined(TARGET_STM32H753ZI))
-#define INITIAL_SP              (0x24080000UL)
-
 
 #else
 #error "INITIAL_SP is not defined for this target in the mbed_rtx.h file"

--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -278,5 +278,8 @@
         "OGChipSelectEditMenu": "TMPM3H6FWFG\tToshiba TMPM3H6FWFG",
         "GFPUCoreSlave": 24,
         "GBECoreSlave": 24
+    },
+    "STM32H743ZI": {
+        "OGChipSelectEditMenu": "STM32H743ZI\tST STM32H743ZI"
     }
 }


### PR DESCRIPTION
Using the DTCM RAM at 0x20000000 fixes the InterruptIn ci-test issue on all toolchains.