### PR TITLE
NUCLEO_H743ZI: add FLASH feature

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/flash_api.c
@@ -120,7 +120,7 @@ int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data,
 
     StartAddress = address;
     while ((address < (StartAddress + size)) && (status == 0)) {
-        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, address, ((uint64_t*)data)) == HAL_OK) {
+        if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_FLASHWORD, address, (uint32_t)data) == HAL_OK) {
             address = address + 32;
             data = data + 32;
         } else {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1496,7 +1496,7 @@
         },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0813"],
-        "device_has_add": ["TRNG", "ANALOGOUT", "CRC"],
+        "device_has_add": ["TRNG", "ANALOGOUT", "CRC", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32H743ZI"
     },


### PR DESCRIPTION
The correction is the the flash_api.c has been done for IAR (build was failed) but it was ok for ARM and GCC.

tests-\*flash\* (tests-mbed_drivers-flashiap, tests-mbed_hal-flash) are PASS on all toolchains