### PR TITLE
Make SPI work

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/TARGET_STM32H743xI/TARGET_NUCLEO_H743ZI/system_clock.c
@@ -131,11 +131,11 @@ uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
     RCC_OscInitStruct.PLL.PLLM = 4;
     RCC_OscInitStruct.PLL.PLLN = 400;
     RCC_OscInitStruct.PLL.PLLP = 2;
-    RCC_OscInitStruct.PLL.PLLQ = 4;
+    RCC_OscInitStruct.PLL.PLLQ = 32;
     RCC_OscInitStruct.PLL.PLLR = 2;
     RCC_OscInitStruct.PLL.PLLFRACN = 0;
     RCC_OscInitStruct.PLL.PLLVCOSEL = RCC_PLL1VCOWIDE;
-    RCC_OscInitStruct.PLL.PLLRGE = RCC_PLL1VCIRANGE_2;
+    RCC_OscInitStruct.PLL.PLLRGE = RCC_PLL1VCIRANGE_1;
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         return 0; // FAIL
     }

--- a/targets/TARGET_STM/TARGET_STM32H7/spi_api.c
+++ b/targets/TARGET_STM/TARGET_STM32H7/spi_api.c
@@ -37,6 +37,7 @@
 #include "pinmap.h"
 #include "PeripheralPins.h"
 #include "mbed_error.h"
+#include "spi_device.h"
 
 #if DEVICE_SPI_ASYNCH
     #define SPI_S(obj)    (( struct spi_s *)(&(obj->spi)))
@@ -55,20 +56,23 @@ int spi_get_clock_freq(spi_t *obj) {
 	/* Get source clock depending on SPI instance */
     switch ((int)spiobj->spi) {
         case SPI_1:
+        case SPI_2:
+        case SPI_3:
+            spi_hz = LL_RCC_GetSPIClockFreq(LL_RCC_SPI123_CLKSOURCE);
+            break;
 		case SPI_4:
 		case SPI_5:
+            spi_hz = LL_RCC_GetSPIClockFreq(LL_RCC_SPI45_CLKSOURCE);
+            break;
 		case SPI_6:	
-			/* SPI_1, SPI_4, SPI_5 and SPI_6. Source CLK is PCKL2 */
-			spi_hz = HAL_RCC_GetPCLK2Freq();
-			break;
-		case SPI_2:
-		case SPI_3:
-			/* SPI_2 and SPI_3. Source CLK is PCKL1 */
-			spi_hz = HAL_RCC_GetPCLK1Freq();
-			break;
+            spi_hz = LL_RCC_GetSPIClockFreq(LL_RCC_SPI6_CLKSOURCE);
+            break;
 		default:
 			error("CLK: SPI instance not set");
             break;
+    }
+    if (spi_hz == LL_RCC_PERIPH_FREQUENCY_NO) {
+        error("spi_hz not found\n");
     }
     return spi_hz;
 }

--- a/targets/TARGET_STM/TARGET_STM32H7/spi_device.h
+++ b/targets/TARGET_STM/TARGET_STM32H7/spi_device.h
@@ -30,6 +30,7 @@
 #ifndef MBED_SPI_DEVICE_H
 #define MBED_SPI_DEVICE_H
 
+#include "stm32h7xx_ll_rcc.h"
 #include "stm32h7xx_ll_spi.h"
 
 #endif

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -187,6 +187,11 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     handle->Init.FirstBit          = SPI_FIRSTBIT_MSB;
     handle->Init.TIMode            = SPI_TIMODE_DISABLE;
 
+#if TARGET_STM32H7
+    handle->Init.NSSPMode          = SPI_NSS_PULSE_DISABLE;
+    handle->Init.MasterKeepIOState = SPI_MASTER_KEEP_IO_STATE_ENABLE;
+#endif
+
     init_spi(obj);
 }
 
@@ -416,7 +421,7 @@ int spi_master_write(spi_t *obj, int value)
 
     /*  Here we're using LL which means direct registers access
      *  There is no error management, so we may end up looping
-     *  infinitely here in case of faulty device for insatnce,
+     *  infinitely here in case of faulty device for instance,
      *  but this will increase performances significantly
      */
 

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -311,7 +311,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
  */
 extern int spi_get_clock_freq(spi_t *obj);
 
-static const uint16_t baudrate_prescaler_table[] =  {SPI_BAUDRATEPRESCALER_2,
+static const uint32_t baudrate_prescaler_table[] =  {SPI_BAUDRATEPRESCALER_2,
                                                      SPI_BAUDRATEPRESCALER_4,
                                                      SPI_BAUDRATEPRESCALER_8,
                                                      SPI_BAUDRATEPRESCALER_16,

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -394,6 +394,16 @@ int spi_master_write(spi_t *obj, int value)
     if (handle->Init.Direction == SPI_DIRECTION_1LINE) {
         return HAL_SPI_Transmit(handle, (uint8_t *)&value, 1, TIMEOUT_1_BYTE);
     }
+#if TARGET_STM32H7
+    else {
+        int retval = 0;
+        if (HAL_SPI_TransmitReceive(handle, (uint8_t *)&value, (uint8_t *)&retval, 1, TIMEOUT_1_BYTE) != HAL_OK) {
+            error("spi transmit receive error\n");
+        }
+        return retval;
+    }
+#else
+
 
 #if defined(LL_SPI_RX_FIFO_TH_HALF)
     /*  Configure the default data size */
@@ -435,6 +445,7 @@ int spi_master_write(spi_t *obj, int value)
     } else {
         return LL_SPI_ReceiveData8(SPI_INST(obj));
     }
+#endif
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,


### PR DESCRIPTION
With this PR, ci-test-shield/tests/API/SPI is working

Modif : 
Add missing fields for spi init function
Fix SPI write function for STM32H743 (use HAL instead of LL for STM32H7)
Fix spi_get_clock_freq for STM32H7 family
Change PLL1_Q clock from 200 MHz to 25MHz (able to reach 100kHz frequency for SPI)
Bug fix SPI baudrate prescaler table is uint32_t

```
+-----------------------+---------------+---------------+--------+--------------------+-------------+
| target                | platform_name | test suite    | result | elapsed_time (sec) | copy_method |
+-----------------------+---------------+---------------+--------+--------------------+-------------+
| NUCLEO_H743ZI-GCC_ARM | NUCLEO_H743ZI | tests-api-spi | OK     | 17.54              | default     |
+-----------------------+---------------+---------------+--------+--------------------+-------------+
```
